### PR TITLE
Correção ortográfica: Python no capítulo 1

### DIFF
--- a/livro/capitulos/1_introducao.asc
+++ b/livro/capitulos/1_introducao.asc
@@ -126,7 +126,7 @@ para a CPU via Barramento de Dados. As instruções são
 desenvolvidas pelo programador, através de linguagens de 
 programação. As ferramentas de compilação transformam os 
 programas escritos em linguagens de alto nível, como C, Java e 
-Phython, em instruções de máquina, que são finalmente copiadas 
+Python, em instruções de máquina, que são finalmente copiadas 
 para a memória no momento em que precisam ser executadas. Cada 
 instrução é armazenada em um endereço diferente da memória. Na 
 execução normal, a CPU passa para a memória, via Barramento de 


### PR DESCRIPTION
correto é Python e não Phython